### PR TITLE
Broken link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ahdinosaur/crud-action-creators.git"
+    "url": "git+https://github.com/ahdinosaur/feathers-action-creators.git"
   },
   "keywords": [
     "redux",
@@ -54,7 +54,7 @@
   "author": "Mikey <michael.williams@enspiral.com> (http://dinosaur.os)",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/ahdinosaur/crud-action-creators/issues"
+    "url": "https://github.com/ahdinosaur/feathers-action-creators/issues"
   },
-  "homepage": "https://github.com/ahdinosaur/crud-action-creators#readme"
+  "homepage": "https://github.com/ahdinosaur/feathers-action-creators#readme"
 }


### PR DESCRIPTION
Currently `https://github.com/ahdinosaur/crud-action-creators/issues`

Expected `https://github.com/ahdinosaur/feathers-action-creators/issues`

This translates to a broken link in the npm module documentation - https://www.npmjs.com/package/feathers-action-creators

Pull request to come
